### PR TITLE
Include metadata dates in converter output

### DIFF
--- a/src/Tests/Samples.VerifyDocumentWithMetadata.verified.txt
+++ b/src/Tests/Samples.VerifyDocumentWithMetadata.verified.txt
@@ -6,7 +6,9 @@
     Keywords: keyword1, keyword2,
     Producer: The Producer,
     Title: The Title,
-    Subject: The Subject
+    Subject: The Subject,
+    CreationDate: DateTimeOffset_1,
+    ModifiedDate: DateTimeOffset_1
   },
   Settings: {
     ContentDirection: LeftToRight,

--- a/src/Verify.QuestPDF/DocumentMetadataConverter.cs
+++ b/src/Verify.QuestPDF/DocumentMetadataConverter.cs
@@ -10,6 +10,8 @@ class DocumentMetadataConverter :
         writer.WriteMember(value, value.Producer, "Producer");
         writer.WriteMember(value, value.Title, "Title");
         writer.WriteMember(value, value.Subject, "Subject");
+        writer.WriteMember(value, value.CreationDate, "CreationDate");
+        writer.WriteMember(value, value.ModifiedDate, "ModifiedDate");
         writer.WriteEnd();
     }
 }


### PR DESCRIPTION
DocumentMetadataConverter now writes `CreationDate` and `ModifiedDate` alongside existing metadata fields. The verified sample output was updated to reflect the two new serialized members (scrubbed as `DateTimeOffset_1`).